### PR TITLE
Change: Improved getDominantColor performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokedexvue",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokedexvue",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@capacitor/android": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "concurrently -k \"vite\" \"wait-on tcp:5173 && electron .\"",
     "dev:electron": "electron .",
-    "dev:web" : "concurrently -k \"vite\"",
+    "dev:web": "concurrently -k \"vite\"",
     "build:web": "vite build",
     "build:electron": "vite build && electron-builder -l AppImage",
     "build": "npm run build:web && electron-builder -l AppImage",
@@ -43,6 +43,7 @@
     "@capacitor/app": "^7.1.0",
     "@capacitor/core": "^7.4.3",
     "@tailwindcss/vite": "^4.1.14",
+    "@vueuse/core": "^14.0.0",
     "axios": "^1.12.2",
     "dotenv": "^17.2.3",
     "pinia": "^3.0.3",

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main-container">
+  <div ref="main-container" class="main-container">
     <NavBar />
     <RouterView
       class="mx-auto md:max-w-screen-2xl mb-24 sm:mb-14 px-4 2xl:px-0 py-6"
@@ -10,9 +10,12 @@
 <script setup>
 import NavBar from "@/renderer/components/Navbar/Navbar.vue";
 import { useAppSettingsStore } from "@/renderer/stores/appSettingsStore";
+import { usePokemonStore } from "./stores/pokemonStore";
 
+const pokemonStore = usePokemonStore()
 const appSettings = useAppSettingsStore()
 
+pokemonStore.resetState()
 appSettings.initDefaults(true)
 </script>
 

--- a/src/renderer/views/PokemonListView/PokemonListView.vue
+++ b/src/renderer/views/PokemonListView/PokemonListView.vue
@@ -12,7 +12,7 @@
       <button
         v-if="listLength > 0"
         @click="loadMore"
-        class="secondary-text-color secondary-background-color mx-auto block px-12 py-3 rounded-xl font-semibold cursor-pointer flex items-center justify-center"
+        class="secondary-text-color secondary-background-color mx-auto px-12 py-3 rounded-xl font-semibold cursor-pointer flex items-center justify-center"
         :disabled="loading"
       >
         <span v-if="!loading">Load more</span>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Now getDominantColor is separated to two functions. One gets the medianLight only, so the card reders faster, then calculates the other two, medianAverage and medianDark.
Now cards render individualy, not in block, so you have content earlier.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora Linux
- **OS Version:** 42
- **PokedexVue version:** 0.0.4

## Additional context
<!-- Add any other context about the pull request here. -->